### PR TITLE
Fix depreciation warning in the sample code

### DIFF
--- a/packages/slate-drop-or-paste-images/Readme.md
+++ b/packages/slate-drop-or-paste-images/Readme.md
@@ -24,7 +24,7 @@ import { Editor } from 'slate-react'
 const plugins = [
   InsertImages({
     extensions: ['png'],
-    applyTransform: (transform, file) => {
+    insertImage: (transform, file) => {
       return transform.insertBlock({
         type: 'image',
         isVoid: true,


### PR DESCRIPTION
As per depreciation warning `applyTransform` is renamed to `insertImage`.