### PR TITLE
Give access to Editor from image plugin

### DIFF
--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -43,7 +43,7 @@ function DropOrPasteImages(options = {}) {
 
   function asyncApplyChange(change, editor, file) {
     return Promise
-      .resolve(insertImage(change, file))
+      .resolve(insertImage(change, file, editor))
       .then(() => {
         editor.onChange(change)
       })


### PR DESCRIPTION
This PR adds a parameter to `insertImage` function that gives access to Slate's Editor component props.

I've added this to satisfy a use case I have and others also may have once they build a higher-level editor package based on Slate:

I have a component that contains a number of Slate packages, plugins and a bunch of other UI and functionality tools. I want it to be useable to the end user by simply adding `<Component options={} />`, where `options` can contain things like acceptable file types when inserting images. That prop is then being given to Slate's Editor component: `<Editor options={this.props.options} />` which will need to be accessible from `insertImage` plugin. Adding this third parameter will give the plugin that access.