### PR TITLE
`slate-drag-or-paste-images`: Added `fallsThrough` as an optional flag for passing on event handling for other plugins in the stack.

### DIFF
--- a/packages/slate-drop-or-paste-images/Readme.md
+++ b/packages/slate-drop-or-paste-images/Readme.md
@@ -45,3 +45,4 @@ Option | Type | Description
 --- | --- | ---
 **`insertImage`** | `Function` | A transforming function that is passed a Slate `Change` and a `File` object representing an image. It should apply the proper transform that inserts the image into Slate based on your schema. It can return a promise resolved with the resulting Slate `Change`.
 **`extensions`** | `Array` | An array of allowed extensions.
+**`fallsThrough`** | `Boolean` | A boolean indicating whether the plugin should allow other plugins in the stack to handle the unhandled drop/paste events or not.

--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -13,6 +13,7 @@ import { getEventTransfer, getEventRange } from 'slate-react'
  * @param {Object} options
  *   @property {Function} insertImage
  *   @property {Array} extensions (optional)
+ *   @property {Boolean} fallsThrough (optional)
  * @return {Object} plugin
  */
 
@@ -20,6 +21,7 @@ function DropOrPasteImages(options = {}) {
   let {
     insertImage,
     extensions,
+    fallsThrough,
   } = options
 
   if (options.applyTransform) {
@@ -92,7 +94,7 @@ function DropOrPasteImages(options = {}) {
    * @param {Editor} editor
    * @param {Object} transfer
    * @param {Range} range
-   * @return {Boolean}
+   * @return {Boolean | void}
    */
 
   function onInsertFiles(event, change, editor, transfer, range) {
@@ -112,7 +114,9 @@ function DropOrPasteImages(options = {}) {
       asyncApplyChange(change, editor, file)
     }
 
-    return true
+    if (!fallsThrough) {
+      return true
+    }
   }
 
   /**
@@ -123,7 +127,7 @@ function DropOrPasteImages(options = {}) {
    * @param {Editor} editor
    * @param {Object} transfer
    * @param {Range} range
-   * @return {Boolean}
+   * @return {Boolean | void}
    */
 
   function onInsertHtml(event, change, editor, transfer, range) {
@@ -148,7 +152,9 @@ function DropOrPasteImages(options = {}) {
       asyncApplyChange(c, editor, file)
     })
 
-    return true
+    if (!fallsThrough) {
+      return true
+    }
   }
 
   /**
@@ -159,7 +165,7 @@ function DropOrPasteImages(options = {}) {
    * @param {Editor} editor
    * @param {Object} transfer
    * @param {Range} range
-   * @return {Boolean}
+   * @return {Boolean | void}
    */
 
   function onInsertText(event, change, editor, transfer, range) {
@@ -173,6 +179,10 @@ function DropOrPasteImages(options = {}) {
       if (range) c.select(range)
       asyncApplyChange(c, editor, file)
     })
+
+    if (!fallsThrough) {
+      return true
+    }
 
     return true
   }


### PR DESCRIPTION
Currently, `slate-drag-or-paste-images` plugin prevents all `onDrop` and `onPaste` event handling on other plugin within the stack by returning `true`.

I've added `fallsThrough` flag in the option to allow other plugins in the stack to handle event properly.