### PR TITLE
Allow drop-or-paste plugin to fall through if processing fails.

### DIFF
--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -110,9 +110,9 @@ function DropOrPasteImages(options = {}) {
       }
 
       asyncApplyChange(change, editor, file)
-    }
 
-    return true
+      return true
+    }
   }
 
   /**
@@ -146,9 +146,8 @@ function DropOrPasteImages(options = {}) {
       const c = editor.value.change()
       if (range) c.select(range)
       asyncApplyChange(c, editor, file)
+      return true
     })
-
-    return true
   }
 
   /**
@@ -172,9 +171,8 @@ function DropOrPasteImages(options = {}) {
       const c = editor.value.change()
       if (range) c.select(range)
       asyncApplyChange(c, editor, file)
+      return true
     })
-
-    return true
   }
 
   /**


### PR DESCRIPTION
:wave: Hey there! This is an exceedingly small suggested change to the drop-or-paste plugin that keeps the processing functions from returning `true` and blocking additional plugins in cases where this plugin fails to handle the change.

The use-case for my project was to permit uploading either animated GIFs or static images, but to map them to two different block components. Previously, this was impossible, as only one instance of this plugin could respond to dropped/pasted files. With this change, I can create one instance that maps static images to one component and one instance that maps GIFs to another.

Thanks for considering it!