### PR TITLE
slate-auto-replace: Add support to Slate 0.40

### DIFF
--- a/examples/slate-auto-replace/index.js
+++ b/examples/slate-auto-replace/index.js
@@ -22,12 +22,12 @@ class Example extends React.Component {
     AutoReplace({
       trigger: 'space',
       before: /^(>)$/,
-      change: change => change.setBlock('blockquote'),
+      change: change => change.setBlocks('blockquote'),
     }),
     AutoReplace({
       trigger: 'space',
       before: /^(-)$/,
-      change: change => change.setBlock('li').wrapBlock('ul'),
+      change: change => change.setBlocks('li').wrapBlock('ul'),
     }),
     AutoReplace({
       trigger: 'space',
@@ -35,7 +35,7 @@ class Example extends React.Component {
       change: (change, event, matches) => {
         const [ hashes ] = matches.before
         const level = hashes.length
-        return change.setBlock({
+        return change.setBlocks({
           type: 'h',
           data: { level }
         })
@@ -44,7 +44,7 @@ class Example extends React.Component {
     AutoReplace({
       trigger: 'enter',
       before: /^(-{3})$/,
-      change: change => change.setBlock({ type: 'hr', isVoid: true }),
+      change: change => change.setBlocks({ type: 'hr', isVoid: true }),
     })
   ]
 

--- a/packages/slate-auto-replace/Readme.md
+++ b/packages/slate-auto-replace/Readme.md
@@ -14,8 +14,8 @@ const plugins = [
   AutoReplace({
     trigger: 'space',
     before: /^(>)$/,
-    transform: (transform, e, matches) => {
-      return transform.setBlock({ type: 'quote' })
+    change: (change, e, matches) => {
+      return change.setBlocks({ type: 'quote' })
     }
   })
 ]
@@ -30,6 +30,6 @@ const plugins = [
 Option | Type | Description
 --- | --- | ---
 **`trigger`** | `String` `RegExp` `Function` | The trigger to match the inputed character against—either a character like `a` or a key name like `enter` or `tab`.
-**`transform`** | `Function` | A function to apply the desired transform. It will be called with `transform, e, matches, editor` from the event handler. The matching (`before` and `after`) text is deleted but are accessible inside `matches.before` and `matches.after`.
-**`after`** | `RegExp` | An optional regexp that must match the text after the trigger for the replacement to occur. Any capturing groups in the regexp will be deleted from the text content, but is accessible in `matches` parameter in the `transform` function.
-**`before`** | `RegExp` | An optional regexp that must match the text before the trigger for the replacement to occur. Any capturing groups in the regexp will be deleted from the text content, but is accessible in `matches` parameter in the `transform` function.
+**`change`** | `Function` | A function to apply the desired change. It will be called with `change, e, matches, editor` from the event handler. The matching (`before` and `after`) text is deleted but are accessible inside `matches.before` and `matches.after`.
+**`after`** | `RegExp` | An optional regexp that must match the text after the trigger for the replacement to occur. Any capturing groups in the regexp will be deleted from the text content, but is accessible in `matches` parameter in the `change` function.
+**`before`** | `RegExp` | An optional regexp that must match the text before the trigger for the replacement to occur. Any capturing groups in the regexp will be deleted from the text content, but is accessible in `matches` parameter in the `change` function.

--- a/packages/slate-auto-replace/src/index.js
+++ b/packages/slate-auto-replace/src/index.js
@@ -60,7 +60,7 @@ function AutoReplace(opts = {}) {
 
     offsets.forEach((offset) => {
       change
-        .moveOffsetsTo(offset.start, offset.end)
+        .moveFocusTo(offset.start, offset.end)
         .delete()
       totalRemoved += offset.total
     })


### PR DESCRIPTION
`slate-auto-replace` isn't working as expected when used with Slate 0.40, primarily due to the usage of the deprecated `moveOffsetsTo`.

I have replaced `moveOffsetsTo` by `moveFocusTo` and updated the docs to refer to the change function (instead of transform) and to use setBlocks (instead of setBlock).

Oh, and BTW, thank you very much for all the hard work on Slate, it's amazing! 😉