### PR TITLE
Update slate-drop-or-paste-images to slate to >= 0.43

### DIFF
--- a/examples/slate-drop-or-paste-images/index.js
+++ b/examples/slate-drop-or-paste-images/index.js
@@ -46,7 +46,7 @@ class Image extends React.Component {
 class Example extends React.Component {
   plugins = [
     DropOrPasteImages({
-      insertImage: (transform, file, _context) => {
+      insertImage: (_event, transform, file, _context) => {
         return transform.insertBlock({
           type: 'image',
           isVoid: true,

--- a/examples/slate-drop-or-paste-images/index.js
+++ b/examples/slate-drop-or-paste-images/index.js
@@ -46,7 +46,7 @@ class Image extends React.Component {
 class Example extends React.Component {
   plugins = [
     DropOrPasteImages({
-      insertImage: (transform, file) => {
+      insertImage: (transform, file, _context) => {
         return transform.insertBlock({
           type: 'image',
           isVoid: true,

--- a/packages/slate-drop-or-paste-images/Changelog.md
+++ b/packages/slate-drop-or-paste-images/Changelog.md
@@ -9,6 +9,8 @@ This document maintains a list of changes. Until `1.0.0` is released, breaking c
 - Update for `slate@0.43`.
 - Add `event` and contextual `source` argument to `insertImage` to provide hinting on how
 image was parsed.
+- Add `acceptableTransferTypes` option to filter which events are handled or
+skipped.
 
 ---
 

--- a/packages/slate-drop-or-paste-images/Changelog.md
+++ b/packages/slate-drop-or-paste-images/Changelog.md
@@ -4,6 +4,14 @@ This document maintains a list of changes. Until `1.0.0` is released, breaking c
 
 ---
 
+### `0.10.0` — November 19, 2018
+
+- Update for `slate@0.43`.
+- Add contextual `source` argument to `insertImage` to provide hinting on how
+image was parsed.
+
+---
+
 ### `0.9.0` — October 10, 2018
 
 - Update for `slate@0.42`.

--- a/packages/slate-drop-or-paste-images/Changelog.md
+++ b/packages/slate-drop-or-paste-images/Changelog.md
@@ -7,7 +7,7 @@ This document maintains a list of changes. Until `1.0.0` is released, breaking c
 ### `0.10.0` — November 19, 2018
 
 - Update for `slate@0.43`.
-- Add contextual `source` argument to `insertImage` to provide hinting on how
+- Add `event` and contextual `source` argument to `insertImage` to provide hinting on how
 image was parsed.
 
 ---

--- a/packages/slate-drop-or-paste-images/Readme.md
+++ b/packages/slate-drop-or-paste-images/Readme.md
@@ -23,7 +23,7 @@ import { Editor } from 'slate-react'
 const plugins = [
   InsertImages({
     extensions: ['png'],
-    insertImage: (change, file) => {
+    insertImage: (change, file, _context) => {
       return change.insertBlock({
         type: 'image',
         isVoid: true,
@@ -40,7 +40,7 @@ const plugins = [
 />
 ```
 
-| Option            | Type       | Description                                                                                                                                                                                                                                                         |
-| ----------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`insertImage`** | `Function` | A transforming function that is passed a Slate `Change` and a `File` object representing an image. It should apply the proper transform that inserts the image into Slate based on your schema. It can return a promise resolved with the resulting Slate `Change`. |
-| **`extensions`**  | `Array`    | An array of allowed extensions.                                                                                                                                                                                                                                     |
+| Option            | Type       | Description                                                                                                                                                                                                                                                                       |
+| ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`insertImage`** | `Function` | A transforming function that is passed a Slate `Change`, a `File` representing an image, and a `context` object. It should apply the proper transform that inserts the image into Slate based on your schema. It can return a promise resolved with the resulting Slate `Change`. |
+| **`extensions`**  | `Array`    | An array of allowed extensions.                                                                                                                                                                                                                                                   |

--- a/packages/slate-drop-or-paste-images/Readme.md
+++ b/packages/slate-drop-or-paste-images/Readme.md
@@ -23,7 +23,7 @@ import { Editor } from 'slate-react'
 const plugins = [
   InsertImages({
     extensions: ['png'],
-    insertImage: (change, file, _context) => {
+    insertImage: (_event, change, file, _context) => {
       return change.insertBlock({
         type: 'image',
         isVoid: true,
@@ -42,5 +42,5 @@ const plugins = [
 
 | Option            | Type       | Description                                                                                                                                                                                                                                                                       |
 | ----------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`insertImage`** | `Function` | A transforming function that is passed a Slate `Change`, a `File` representing an image, and a `context` object. It should apply the proper transform that inserts the image into Slate based on your schema. It can return a promise resolved with the resulting Slate `Change`. |
+| **`insertImage`** | `Function` | A transforming function that is passed an `Event`, Slate `Change`, a `File` representing an image, and a `context` object. It should apply the proper transform that inserts the image into Slate based on your schema. It can return a promise resolved with the resulting Slate `Change`. |
 | **`extensions`**  | `Array`    | An array of allowed extensions.                                                                                                                                                                                                                                                   |

--- a/packages/slate-drop-or-paste-images/package.json
+++ b/packages/slate-drop-or-paste-images/package.json
@@ -21,7 +21,7 @@
     "slate-dev-logger": "^0.1.0"
   },
   "peerDependencies": {
-    "slate": ">=0.42.2",
+    "slate": ">=0.43.0",
     "slate-react": ">=0.19.3"
   },
   "keywords": [

--- a/packages/slate-drop-or-paste-images/src/image-to-data-uri.js
+++ b/packages/slate-drop-or-paste-images/src/image-to-data-uri.js
@@ -22,7 +22,7 @@ function srcToDataUri(url, callback) {
     callback(null, dataUri)
   }
 
-  img.ononerror = () => {
+  img.onerror = () => {
     callback(new Error('Failed to load image.'))
   }
 

--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -86,9 +86,10 @@ function DropOrPasteImages(options = {}) {
     const { files } = transfer
 
     for (const file of files) {
+      const type = file.type
+      const [, ext] = type.split('/')
+
       if (extensions) {
-        const type = file.type
-        const [, ext] = type.split('/')
         if (!matchExt(ext)) continue
       }
 
@@ -96,7 +97,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'files' })
+      insertImage(editor, file, { source: 'files', ext })
     }
   }
 
@@ -120,9 +121,9 @@ function DropOrPasteImages(options = {}) {
     if (firstChild.nodeName.toLowerCase() != 'img') return next()
 
     const src = firstChild.src
+    const ext = extname(src).slice(1)
 
     if (extensions) {
-      const ext = extname(src).slice(1)
       if (!matchExt(ext)) return next()
     }
 
@@ -133,7 +134,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'html', src })
+      insertImage(editor, file, { source: 'html', src, ext })
     })
   }
 
@@ -160,7 +161,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'text', text })
+      insertImage(editor, file, { source: 'text', text, ext: extname(text).slice(1) })
     })
   }
 

--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -97,7 +97,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'files', ext })
+      insertImage(event, editor, file, { source: 'files', ext })
     }
   }
 
@@ -134,7 +134,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'html', src, ext })
+      insertImage(event, editor, file, { source: 'html', src, ext })
     })
   }
 
@@ -161,7 +161,7 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(editor, file, { source: 'text', text, ext: extname(text).slice(1) })
+      insertImage(event, editor, file, { source: 'text', text, ext: extname(text).slice(1) })
     })
   }
 

--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -1,4 +1,3 @@
-import Promise from 'es6-promise'
 import isImage from 'is-image'
 import isUrl from 'is-url'
 import logger from 'slate-dev-logger'
@@ -48,42 +47,25 @@ function DropOrPasteImages(options = {}) {
   }
 
   /**
-   * Apply the change for a given file and update the editor with the result.
-   *
-   * @param {Change} change
-   * @param {Blob} file
-   * @return {Promise}
-   */
-
-  function asyncApplyChange(change, file) {
-    const { editor } = change
-
-    return Promise.resolve(insertImage(change, file)).then(() => {
-      editor.onChange(change)
-    })
-  }
-
-  /**
    * On drop or paste.
    *
    * @param {Event} event
-   * @param {Change} change
+   * @param {Editor} editor
    * @param {Function} next
    * @return {State}
    */
 
-  function onInsert(event, change, next) {
-    const { editor } = change
+  function onInsert(event, editor, next) {
     const transfer = getEventTransfer(event)
     const range = getEventRange(event, editor)
 
     switch (transfer.type) {
       case 'files':
-        return onInsertFiles(event, change, next, transfer, range)
+        return onInsertFiles(event, editor, next, transfer, range)
       case 'html':
-        return onInsertHtml(event, change, next, transfer, range)
+        return onInsertHtml(event, editor, next, transfer, range)
       case 'text':
-        return onInsertText(event, change, next, transfer, range)
+        return onInsertText(event, editor, next, transfer, range)
       default:
         return next()
     }
@@ -93,14 +75,14 @@ function DropOrPasteImages(options = {}) {
    * On drop or paste files.
    *
    * @param {Event} event
-   * @param {Change} change
+   * @param {Editor} editor
    * @param {Function} next
    * @param {Object} transfer
    * @param {Range} range
    * @return {Boolean}
    */
 
-  function onInsertFiles(event, change, next, transfer, range) {
+  function onInsertFiles(event, editor, next, transfer, range) {
     const { files } = transfer
 
     for (const file of files) {
@@ -111,10 +93,10 @@ function DropOrPasteImages(options = {}) {
       }
 
       if (range) {
-        change.select(range)
+        editor.select(range)
       }
 
-      asyncApplyChange(change, file)
+      insertImage(editor, file, { source: 'files' })
     }
   }
 
@@ -122,15 +104,14 @@ function DropOrPasteImages(options = {}) {
    * On drop or paste html.
    *
    * @param {Event} event
-   * @param {Change} change
+   * @param {Editor} editor
    * @param {Function} next
    * @param {Object} transfer
    * @param {Range} range
    * @return {Boolean}
    */
 
-  function onInsertHtml(event, change, next, transfer, range) {
-    const { editor } = change
+  function onInsertHtml(event, editor, next, transfer, range) {
     const { html } = transfer
     const parser = new DOMParser()
     const doc = parser.parseFromString(html, 'text/html')
@@ -148,13 +129,11 @@ function DropOrPasteImages(options = {}) {
     loadImageFile(src, (err, file) => {
       if (err) return
 
-      editor.change(c => {
-        if (range) {
-          c.select(range)
-        }
+      if (range) {
+        editor.select(range)
+      }
 
-        asyncApplyChange(c, file)
-      })
+      insertImage(editor, file, { source: 'html', src })
     })
   }
 
@@ -162,15 +141,14 @@ function DropOrPasteImages(options = {}) {
    * On drop or paste text.
    *
    * @param {Event} event
-   * @param {Change} change
+   * @param {Editor} editor
    * @param {Function} next
    * @param {Object} transfer
    * @param {Range} range
    * @return {Boolean}
    */
 
-  function onInsertText(event, change, next, transfer, range) {
-    const { editor } = change
+  function onInsertText(event, editor, next, transfer, range) {
     const { text } = transfer
     if (!isUrl(text)) return next()
     if (!isImage(text)) return next()
@@ -178,13 +156,11 @@ function DropOrPasteImages(options = {}) {
     loadImageFile(text, (err, file) => {
       if (err) return
 
-      editor.change(c => {
-        if (range) {
-          c.select(range)
-        }
+      if (range) {
+        editor.select(range)
+      }
 
-        asyncApplyChange(c, editor, file)
-      })
+      insertImage(editor, file, { source: 'text', text })
     })
   }
 

--- a/packages/slate-drop-or-paste-images/src/index.js
+++ b/packages/slate-drop-or-paste-images/src/index.js
@@ -15,7 +15,7 @@ import { getEventTransfer, getEventRange } from 'slate-react'
  */
 
 function DropOrPasteImages(options = {}) {
-  let { insertImage, extensions } = options
+  let { insertImage, extensions, acceptableTransferTypes } = options
 
   if (options.applyTransform) {
     logger.deprecate(
@@ -59,15 +59,22 @@ function DropOrPasteImages(options = {}) {
     const transfer = getEventTransfer(event)
     const range = getEventRange(event, editor)
 
-    switch (transfer.type) {
-      case 'files':
-        return onInsertFiles(event, editor, next, transfer, range)
-      case 'html':
-        return onInsertHtml(event, editor, next, transfer, range)
-      case 'text':
-        return onInsertText(event, editor, next, transfer, range)
-      default:
-        return next()
+    if (
+      !acceptableTransferTypes ||
+      acceptableTransferTypes.includes(transfer.type)
+    ) {
+      switch (transfer.type) {
+        case 'files':
+          return onInsertFiles(event, editor, next, transfer, range)
+        case 'html':
+          return onInsertHtml(event, editor, next, transfer, range)
+        case 'text':
+          return onInsertText(event, editor, next, transfer, range)
+        default:
+          return next()
+      }
+    } else {
+      return next()
     }
   }
 
@@ -161,7 +168,11 @@ function DropOrPasteImages(options = {}) {
         editor.select(range)
       }
 
-      insertImage(event, editor, file, { source: 'text', text, ext: extname(text).slice(1) })
+      insertImage(event, editor, file, {
+        source: 'text',
+        text,
+        ext: extname(text).slice(1),
+      })
     })
   }
 

--- a/packages/slate-drop-or-paste-images/src/load-image-file.js
+++ b/packages/slate-drop-or-paste-images/src/load-image-file.js
@@ -17,6 +17,7 @@ function loadImageFile(url, callback) {
     })
   } else {
     imageToDataUri(url, (err, uri) => {
+      if (err) return callback(err)
       const file = dataUriToBlob(uri)
       callback(err, file)
     })


### PR DESCRIPTION
- [x] change -> editor
- [x] Also add context object to insertImage callback.  Useful to access original src for example.