### PR TITLE
feat: upgrade editor.call to editor.command

### DIFF
--- a/packages/slate-auto-replace/src/index.js
+++ b/packages/slate-auto-replace/src/index.js
@@ -54,7 +54,7 @@ function AutoReplace(opts = {}) {
 
     startOffset -= totalRemoved
     change.moveTo(startOffset)
-    change.call(opts.change, event, matches)
+    change.command(opts.change, event, matches)
   }
 
   /**


### PR DESCRIPTION
Addressing the following warning:

"As of Slate 0.43 the `editor.call(fn)` method has been deprecated, please use `editor.command(fn)` instead."