### PR TITLE
Fix typo and and pass image load errors to callback

### DIFF
--- a/packages/slate-drop-or-paste-images/src/image-to-data-uri.js
+++ b/packages/slate-drop-or-paste-images/src/image-to-data-uri.js
@@ -22,7 +22,7 @@ function srcToDataUri(url, callback) {
     callback(null, dataUri)
   }
 
-  img.ononerror = () => {
+  img.onerror = () => {
     callback(new Error('Failed to load image.'))
   }
 

--- a/packages/slate-drop-or-paste-images/src/load-image-file.js
+++ b/packages/slate-drop-or-paste-images/src/load-image-file.js
@@ -17,8 +17,12 @@ function loadImageFile(url, callback) {
     })
   } else {
     imageToDataUri(url, (err, uri) => {
-      const file = dataUriToBlob(uri)
-      callback(err, file)
+      if (err != null)
+        callback(err)
+      else {
+        const file = dataUriToBlob(uri)
+        callback(null, file)
+      }
     })
   }
 }


### PR DESCRIPTION
Looks like there is a typo in the onerror image callback that I fixed. Also, when that is invoked it caused dataUriToBlob(uri) to error because uri was not defined.